### PR TITLE
Bugfix for localised templates in TS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "medusa-plugin-ses",
-   "version": "2.0.4",
+   "version": "2.0.5",
    "description": "AWS SES transactional emails using local handlebars templates",
    "main": "index.js",
    "repository": {

--- a/src/services/ses.js
+++ b/src/services/ses.js
@@ -242,12 +242,13 @@ class SESService extends NotificationService {
   async sendNotification(event, eventData, attachmentGenerator) {
     let templateId = this.getTemplateId(event)
     if (!templateId) { return false }
-    if (data.locale) {
-      templateId = this.getLocalizedTemplateId(event, data.locale) || templateId
-    }
 
     const data = await this.fetchData(event, eventData, attachmentGenerator)
     if (!data) { return false }
+
+    if (data.locale) {
+      templateId = this.getLocalizedTemplateId(event, data.locale) || templateId
+    }
 
     const { subject, html, text } = await this.compileTemplate(templateId, data)
     if (!subject || (!html && !text)) { return false }


### PR DESCRIPTION
Dear Pevey,

The following PR makes a small change to the code, loading the `data` variable before checking if a locale is present in the sendNotification function.

This solves a bug what I am getting with the data variable being undefined when checking the locale.

The code has been tested locally. I also did a version bump from 2.0.4 to 2.0.5.

Thank you for your work on this plugin and time!

Eliott

Original error:
```
TypeError: Cannot read properties of undefined (reading 'locale')
    at SESService._callee4$ (/backend/node_modules/medusa-plugin-ses/services/ses.js:334:32)                                                                                                        at tryCatch (/backend/node_modules/medusa-plugin-ses/services/ses.js:21:1360)
    at Generator.<anonymous> (/backend/node_modules/medusa-plugin-ses/services/ses.js:21:4177)                                                                                                      at Generator.next (/backend/node_modules/medusa-plugin-ses/services/ses.js:21:2211)
    at asyncGeneratorStep (/backend/node_modules/medusa-plugin-ses/services/ses.js:22:103)
    at _next (/backend/node_modules/medusa-plugin-ses/services/ses.js:23:194)
    at /backend/node_modules/medusa-plugin-ses/services/ses.js:23:364
    at new Promise (<anonymous>)                                                                                                                                                                                          at SESService.<anonymous> (/backend/node_modules/medusa-plugin-ses/services/ses.js:23:97)
    at SESService.sendNotification (/backend/node_modules/medusa-plugin-ses/services/ses.js:407:34)                                                                                                 at NotificationService.<anonymous> (/backend/node_modules/@medusajs/medusa/dist/services/notification.js:296:71)
    at step (/backend/node_modules/@medusajs/medusa/dist/services/notification.js:59:23)                                                                                                            at Object.next (/backend/node_modules/@medusajs/medusa/dist/services/notification.js:40:53)
    at /backend/node_modules/@medusajs/medusa/dist/services/notification.js:34:71
    at new Promise (<anonymous>)
    at __awaiter (/backend/node_modules/@medusajs/medusa/dist/services/notification.js:30:12)
warn:    An error occured while ses was processing a notification for order.placed: Cannot read properties of undefined (reading 'locale')
```